### PR TITLE
Support backing up postgresql databases on Ubuntu 20.04

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -49,6 +49,7 @@ class pf_postgresql::params {
         'Debian': {
             # Latest version available in the distribution's own repositories
             case $::lsbdistcodename {
+                'focal':             { $ver = 12 }
                 'bionic':            { $ver = 10 }
                 'xenial':            { $ver = 9.5 }
                 'jessie':            { $ver = 9.4 }


### PR DESCRIPTION
Other parts of this module are unmaintained, so general Ubuntu 20.04 support
will not be added.

Signed-off-by: Samuli Seppänen <samuli.seppanen@puppeteers.net>